### PR TITLE
Add Auto cap INI option to prevent lossless smelt loops

### DIFF
--- a/Skyrim/Data/SKSE/Plugins/po3_CraftingRecipeDistributor.ini
+++ b/Skyrim/Data/SKSE/Plugins/po3_CraftingRecipeDistributor.ini
@@ -11,3 +11,6 @@ Jewelry cap = 0
 
 ;maximum amount of ingots (or other materials) recieved when smelting clutter
 Clutter cap = 0
+
+;if true, automatically set smelt output to floor(crafting cost / 2) - prevents lossless craft/smelt loops
+Auto cap = false

--- a/src/Distributor.cpp
+++ b/src/Distributor.cpp
@@ -51,12 +51,14 @@ namespace CRAFT
 		ini::get_value(ini, smelt.maxArmorAmount, "SMELT", "Armor cap", ";maximum amount of ingots (or other materials) recieved when smelting armor");
 		ini::get_value(ini, smelt.maxJewelryAmount, "SMELT", "Jewelry cap", ";maximum amount of ingots (or other materials) recieved when smelting jewelry");
 		ini::get_value(ini, smelt.maxClutterAmount, "SMELT", "Clutter cap", ";maximum amount of ingots (or other materials) recieved when smelting clutter");
+		ini::get_value(ini, smelt.autoCap, "SMELT", "Auto cap", ";if true, automatically set smelt output to floor(crafting cost / 2) - prevents lossless craft/smelt loops");
 
 		logger::info("SMELT");
 		logger::info("\tmax weapon cap : {}", smelt.maxWeapAmount);
 		logger::info("\tmax armor cap : {}", smelt.maxArmorAmount);
 		logger::info("\tmax jewelry cap : {}", smelt.maxJewelryAmount);
 		logger::info("\tmax clutter cap : {}", smelt.maxClutterAmount);
+		logger::info("\tauto cap : {}", smelt.autoCap);
 
 		void(ini.SaveFile(path));
 	}

--- a/src/Smelt.cpp
+++ b/src/Smelt.cpp
@@ -94,6 +94,14 @@ namespace CRAFT
 						numConstructed = static_cast<std::uint16_t>(itemGold * 0.5f / ingotGold);
 					}
 				}
+
+				// Auto cap: halve the computed crafting cost (floor), minimum 1.
+				// Prevents lossless craft->smelt->craft loops when no manual cap is set.
+				// Only applies to auto-computed counts; explicit _CRD*.ini overrides are unaffected.
+				if (autoCap && numConstructed > 0) {
+					numConstructed = std::max(static_cast<std::uint16_t>(1),
+					                          static_cast<std::uint16_t>(numConstructed / 2));
+				}
 			}
 
 			std::uint16_t cap = 0;

--- a/src/Smelt.h
+++ b/src/Smelt.h
@@ -20,6 +20,7 @@ namespace CRAFT
 		std::uint16_t maxArmorAmount{ 0 };
 		std::uint16_t maxJewelryAmount{ 0 };
 		std::uint16_t maxClutterAmount{ 0 };
+		bool          autoCap{ false };  // if true, output is floor(craftingCost / 2), min 1
 
 		std::uint32_t weapCount{ 0 };
 		std::uint32_t armorCount{ 0 };


### PR DESCRIPTION
## Problem

Smelting recipes currently return the same number of ingots it costs to craft the item (e.g. an iron sword costs 2 ingots and yields 2 ingots back). This creates lossless craft→smelt→craft loops with no material cost.

## Change

Adds a new `Auto cap` option to `po3_CraftingRecipeDistributor.ini` under `[SMELT]`:

```ini
;if true, automatically set smelt output to floor(crafting cost / 2) - prevents lossless craft/smelt loops
Auto cap = false
```

When enabled, smelt output is set to `floor(craftingCost / 2)` with a minimum of 1:

| Crafting cost | Default | Auto cap on |
|---|---|---|
| 1 ingot | 1 | 1 |
| 2 ingots | 2 | 1 |
| 3 ingots | 3 | 1 |
| 4 ingots | 4 | 2 |
| 6 ingots | 6 | 3 |

## Notes

- Defaults to `false` — no change for existing users
- Only affects auto-computed counts; explicit per-item overrides in `_CRD*.ini` files are always respected
- Compatible with the existing per-category manual caps (`Weapon cap`, `Armor cap`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)